### PR TITLE
(GH-3) Add StyleCop analyzer to test assemebly

### DIFF
--- a/src/Cake.Prca.PullRequests.Tfs.Tests.ruleset
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests.ruleset
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Ruleset for Cake.Prca.PullRequests.Tfs test cases" Description="Rules valid for Cake.Prca.PullRequests.Tfs test cases" ToolsVersion="14.0">
+  <Include Path="Cake.Prca.PullRequests.Tfs.ruleset" Action="Default" />
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1118" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+  </Rules>
+</RuleSet>

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Cake.Prca.PullRequests.Tfs.Tests.csproj
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Cake.Prca.PullRequests.Tfs.Tests.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\Cake.Prca.PullRequests.Tfs.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>..\Cake.Prca.PullRequests.Tfs.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -88,6 +90,11 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Properties/AssemblyInfo.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("TFS support for Cake Pull Request Code Analysis Testcases")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/packages.config
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="Cake.Core" version="0.18.0" targetFramework="net452" />
   <package id="Cake.Testing" version="0.18.0" targetFramework="net452" />
   <package id="Shouldly" version="2.8.2" targetFramework="net452" />
+  <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />

--- a/src/Cake.Prca.PullRequests.Tfs.ruleset
+++ b/src/Cake.Prca.PullRequests.Tfs.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Ruleset for Cake.Prca" Description="Rules valid for Cake.Prca" ToolsVersion="14.0">
+<RuleSet Name="Ruleset for Cake.Prca.PullRequests.Tfs" Description="Rules valid for Cake.Prca.PullRequests.Tfs" ToolsVersion="14.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1000" Action="None" />


### PR DESCRIPTION
Adds StyleCop analyzer to test assemebly and defines separate ruleset for test assemblies with less strict validation.

Fixes #3 