### PR TITLE
(GH-5) Add support for different authentication methods

### DIFF
--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/AuthenticationProviderTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/AuthenticationProviderTests.cs
@@ -1,0 +1,339 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Tests.Authentication
+{
+    using Tfs.Authentication;
+    using Shouldly;
+    using Xunit;
+
+    public class AuthenticationProviderTests
+    {
+        public sealed class TheAuthenticationNtlmMethod
+        {
+            [Fact]
+            public void Should_Return_PrcaNtlmCredentials_Object()
+            {
+                // Given / When
+                var credentials = AuthenticationProvider.AuthenticationNtlm();
+
+                // Then
+                credentials.ShouldBeOfType<PrcaNtlmCredentials>();
+            }
+        }
+
+        public sealed class TheAuthenticationBasicMethod
+        {
+            [Fact]
+            public void Should_Throw_If_User_Name_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationBasic(null, "foo"));
+
+                // Then
+                result.IsArgumentNullException("userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_User_Name_Is_Empty()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationBasic(string.Empty, "foo"));
+
+                // Then
+                result.IsArgumentOutOfRangeException("userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_User_Name_Is_WhiteSpace()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationBasic(" ", "foo"));
+
+                // Then
+                result.IsArgumentOutOfRangeException("userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationBasic("foo", null));
+
+                // Then
+                result.IsArgumentNullException("password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Empty()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationBasic("foo", string.Empty));
+
+                // Then
+                result.IsArgumentOutOfRangeException("password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_WhiteSpace()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationBasic("foo", " "));
+
+                // Then
+                result.IsArgumentOutOfRangeException("password");
+            }
+
+            [Fact]
+            public void Should_Return_PrcaBasicCredentials_Object()
+            {
+                // Given / When
+                var credentials = AuthenticationProvider.AuthenticationBasic("foo", "bar");
+
+                // Then
+                credentials.ShouldBeOfType<PrcaBasicCredentials>();
+            }
+
+            [Fact]
+            public void Should_Set_User_Name()
+            {
+                // Given 
+                const string userName = "foo";
+
+                // When
+                var credentials = AuthenticationProvider.AuthenticationBasic(userName, "bar");
+
+                // Then
+                credentials.ShouldBeOfType<PrcaBasicCredentials>();
+                ((PrcaBasicCredentials)credentials).UserName.ShouldBe(userName);
+            }
+
+            [Fact]
+            public void Should_Set_Password()
+            {
+                // Given 
+                const string password = "bar";
+
+                // When
+                var credentials = AuthenticationProvider.AuthenticationBasic("foo", password);
+
+                // Then
+                credentials.ShouldBeOfType<PrcaBasicCredentials>();
+                ((PrcaBasicCredentials)credentials).Password.ShouldBe(password);
+            }
+        }
+
+        public sealed class TheAuthenticationPersonalAccessTokenMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Personal_Access_Token_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationPersonalAccessToken(null));
+
+                // Then
+                result.IsArgumentNullException("personalAccessToken");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Personal_Access_Token_Is_Empty()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationPersonalAccessToken(string.Empty));
+
+                // Then
+                result.IsArgumentOutOfRangeException("personalAccessToken");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Personal_Access_Token_Is_WhiteSpace()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationPersonalAccessToken(" "));
+
+                // Then
+                result.IsArgumentOutOfRangeException("personalAccessToken");
+            }
+
+            [Fact]
+            public void Should_Return_PrcaBasicCredentials_Object()
+            {
+                // Given / When
+                var credentials = AuthenticationProvider.AuthenticationPersonalAccessToken("foo");
+
+                // Then
+                credentials.ShouldBeOfType<PrcaBasicCredentials>();
+            }
+
+            [Fact]
+            public void Should_Set_Personal_Access_Token()
+            {
+                // Given 
+                const string personalAccessToken = "foo";
+
+                // When
+                var credentials = AuthenticationProvider.AuthenticationPersonalAccessToken(personalAccessToken);
+
+                // Then
+                credentials.ShouldBeOfType<PrcaBasicCredentials>();
+                ((PrcaBasicCredentials)credentials).UserName.ShouldBe(string.Empty);
+                ((PrcaBasicCredentials)credentials).Password.ShouldBe(personalAccessToken);
+            }
+        }
+
+        public sealed class TheAuthenticationOAuthMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Access_Token_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationOAuth(null));
+
+                // Then
+                result.IsArgumentNullException("accessToken");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Access_Token_Is_Empty()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationOAuth(string.Empty));
+
+                // Then
+                result.IsArgumentOutOfRangeException("accessToken");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Access_Token_Is_WhiteSpace()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationOAuth(" "));
+
+                // Then
+                result.IsArgumentOutOfRangeException("accessToken");
+            }
+
+            [Fact]
+            public void Should_Return_PrcaOAuthCredentials_Object()
+            {
+                // Given / When
+                var credentials = AuthenticationProvider.AuthenticationOAuth("foo");
+
+                // Then
+                credentials.ShouldBeOfType<PrcaOAuthCredentials>();
+            }
+
+            [Fact]
+            public void Should_Set_Access_Token()
+            {
+                // Given 
+                const string accessToken = "foo";
+
+                // When
+                var credentials = AuthenticationProvider.AuthenticationOAuth(accessToken);
+
+                // Then
+                credentials.ShouldBeOfType<PrcaOAuthCredentials>();
+                ((PrcaOAuthCredentials)credentials).AccessToken.ShouldBe(accessToken);
+            }
+        }
+
+        public sealed class TheAuthenticationAzureActiveDirectoryMethod
+        {
+            [Fact]
+            public void Should_Throw_If_User_Name_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationAzureActiveDirectory(null, "foo"));
+
+                // Then
+                result.IsArgumentNullException("userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_User_Name_Is_Empty()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationAzureActiveDirectory(string.Empty, "foo"));
+
+                // Then
+                result.IsArgumentOutOfRangeException("userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_User_Name_Is_WhiteSpace()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationAzureActiveDirectory(" ", "foo"));
+
+                // Then
+                result.IsArgumentOutOfRangeException("userName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationAzureActiveDirectory("foo", null));
+
+                // Then
+                result.IsArgumentNullException("password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_Empty()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationAzureActiveDirectory("foo", string.Empty));
+
+                // Then
+                result.IsArgumentOutOfRangeException("password");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Password_Is_WhiteSpace()
+            {
+                // Given / When
+                var result = Record.Exception(() => AuthenticationProvider.AuthenticationAzureActiveDirectory("foo", " "));
+
+                // Then
+                result.IsArgumentOutOfRangeException("password");
+            }
+
+            [Fact]
+            public void Should_Return_PrcaAadCredentials_Object()
+            {
+                // Given / When
+                var credentials = AuthenticationProvider.AuthenticationAzureActiveDirectory("foo", "bar");
+
+                // Then
+                credentials.ShouldBeOfType<PrcaAadCredentials>();
+            }
+
+            [Fact]
+            public void Should_Set_User_Name()
+            {
+                // Given 
+                const string userName = "foo";
+
+                // When
+                var credentials = AuthenticationProvider.AuthenticationAzureActiveDirectory(userName, "bar");
+
+                // Then
+                credentials.ShouldBeOfType<PrcaAadCredentials>();
+                ((PrcaAadCredentials)credentials).UserName.ShouldBe(userName);
+            }
+
+            [Fact]
+            public void Should_Set_Password()
+            {
+                // Given 
+                const string password = "bar";
+
+                // When
+                var credentials = AuthenticationProvider.AuthenticationAzureActiveDirectory("foo", password);
+
+                // Then
+                credentials.ShouldBeOfType<PrcaAadCredentials>();
+                ((PrcaAadCredentials)credentials).Password.ShouldBe(password);
+            }
+        }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/AuthenticationProviderTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/AuthenticationProviderTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Cake.Prca.PullRequests.Tfs.Tests.Authentication
 {
-    using Tfs.Authentication;
     using Shouldly;
+    using Tfs.Authentication;
     using Xunit;
 
     public class AuthenticationProviderTests
@@ -94,7 +94,7 @@
             [Fact]
             public void Should_Set_User_Name()
             {
-                // Given 
+                // Given
                 const string userName = "foo";
 
                 // When
@@ -108,7 +108,7 @@
             [Fact]
             public void Should_Set_Password()
             {
-                // Given 
+                // Given
                 const string password = "bar";
 
                 // When
@@ -165,7 +165,7 @@
             [Fact]
             public void Should_Set_Personal_Access_Token()
             {
-                // Given 
+                // Given
                 const string personalAccessToken = "foo";
 
                 // When
@@ -223,7 +223,7 @@
             [Fact]
             public void Should_Set_Access_Token()
             {
-                // Given 
+                // Given
                 const string accessToken = "foo";
 
                 // When
@@ -310,7 +310,7 @@
             [Fact]
             public void Should_Set_User_Name()
             {
-                // Given 
+                // Given
                 const string userName = "foo";
 
                 // When
@@ -324,7 +324,7 @@
             [Fact]
             public void Should_Set_Password()
             {
-                // Given 
+                // Given
                 const string password = "bar";
 
                 // When

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaAadCredentialsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaAadCredentialsTests.cs
@@ -1,0 +1,40 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Tests.Authentication
+{
+    using Shouldly;
+    using Tfs.Authentication;
+    using Xunit;
+
+    public class PrcaAadCredentialsTests
+    {
+        public sealed class ThePrcaAadCredentialsCtor
+        {
+            [Theory]
+            [InlineData("foo")]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData(" ")]
+            public void Should_Set_User_Name(string userName)
+            {
+                // When
+                var credentials = new PrcaAadCredentials(userName, "bar");
+
+                // Then
+                credentials.UserName.ShouldBe(userName);
+            }
+
+            [Theory]
+            [InlineData("bar")]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData(" ")]
+            public void Should_Set_Password_Name(string password)
+            {
+                // When
+                var credentials = new PrcaAadCredentials("foo", password);
+
+                // Then
+                credentials.Password.ShouldBe(password);
+            }
+        }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaBasicCredentialsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaBasicCredentialsTests.cs
@@ -1,0 +1,40 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Tests.Authentication
+{
+    using Shouldly;
+    using Tfs.Authentication;
+    using Xunit;
+
+    public class PrcaBasicCredentialsTests
+    {
+        public sealed class ThePrcaBasicCredentialsCtor
+        {
+            [Theory]
+            [InlineData("foo")]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData(" ")]
+            public void Should_Set_User_Name(string userName)
+            {
+                // When
+                var credentials = new PrcaBasicCredentials(userName, "bar");
+
+                // Then
+                credentials.UserName.ShouldBe(userName);
+            }
+
+            [Theory]
+            [InlineData("bar")]
+            [InlineData(null)]
+            [InlineData("")]
+            [InlineData(" ")]
+            public void Should_Set_Password_Name(string password)
+            {
+                // When
+                var credentials = new PrcaBasicCredentials("foo", password);
+
+                // Then
+                credentials.Password.ShouldBe(password);
+            }
+        }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaNtlmCredentialsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaNtlmCredentialsTests.cs
@@ -1,0 +1,22 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Tests.Authentication
+{
+    using Shouldly;
+    using Tfs.Authentication;
+    using Xunit;
+
+    public class PrcaNtlmCredentialsTests
+    {
+        public sealed class ThePrcaNtlmCredentialsCtor
+        {
+            [Fact]
+            public void Should_Not_Throw()
+            {
+                // Given / When
+                var credentials = new PrcaNtlmCredentials();
+
+                // Then
+                credentials.ShouldBeOfType<PrcaNtlmCredentials>();
+            }
+        }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaOAuthCredentialsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaOAuthCredentialsTests.cs
@@ -1,0 +1,55 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Tests.Authentication
+{
+    using Shouldly;
+    using Tfs.Authentication;
+    using Xunit;
+
+    public class PrcaOAuthCredentialsTests
+    {
+        public sealed class ThePrcaOAuthCredentialsCtor
+        {
+            [Fact]
+            public void Should_Throw_If_Access_Token_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => new PrcaOAuthCredentials(null));
+
+                // Then
+                result.IsArgumentNullException("accessToken");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Access_Token_Is_Empty()
+            {
+                // Given / When
+                var result = Record.Exception(() => new PrcaOAuthCredentials(string.Empty));
+
+                // Then
+                result.IsArgumentOutOfRangeException("accessToken");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Access_Token_Is_WhiteSpace()
+            {
+                // Given / When
+                var result = Record.Exception(() => new PrcaOAuthCredentials(" "));
+
+                // Then
+                result.IsArgumentOutOfRangeException("accessToken");
+            }
+
+            [Fact]
+            public void Should_Set_Access_Token()
+            {
+                // Given
+                const string accessToken = "foo";
+
+                // When
+                var credentials = new PrcaOAuthCredentials(accessToken);
+
+                // Then
+                credentials.AccessToken.ShouldBe(accessToken);
+            }
+        }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Cake.Prca.PullRequests.Tfs.Tests.csproj
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Cake.Prca.PullRequests.Tfs.Tests.csproj
@@ -73,6 +73,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Authentication\AuthenticationProviderTests.cs" />
+    <Compile Include="Authentication\PrcaAadCredentialsTests.cs" />
+    <Compile Include="Authentication\PrcaNtlmCredentialsTests.cs" />
+    <Compile Include="Authentication\PrcaOAuthCredentialsTests.cs" />
+    <Compile Include="Authentication\PrcaBasicCredentialsTests.cs" />
     <Compile Include="ExceptionAssertExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepositoryDescriptionTests.cs" />

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/TfsPullRequestSettingsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/TfsPullRequestSettingsTests.cs
@@ -11,7 +11,7 @@
             public void Should_Throw_If_RepositoryUrl_For_SourceBranch_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => new TfsPullRequestSettings((Uri)null, "foo"));
+                var result = Record.Exception(() => new TfsPullRequestSettings((Uri)null, "foo", null));
 
                 // Then
                 result.IsArgumentNullException("repositoryUrl");
@@ -21,7 +21,7 @@
             public void Should_Throw_If_SourceBranch_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => new TfsPullRequestSettings(new Uri("http://example.com"), (string)null));
+                var result = Record.Exception(() => new TfsPullRequestSettings(new Uri("http://example.com"), (string)null, null));
 
                 // Then
                 result.IsArgumentNullException("sourceBranch");
@@ -31,7 +31,7 @@
             public void Should_Throw_If_SourceBranch_Is_Empty()
             {
                 // Given / When
-                var result = Record.Exception(() => new TfsPullRequestSettings(new Uri("http://example.com"), string.Empty));
+                var result = Record.Exception(() => new TfsPullRequestSettings(new Uri("http://example.com"), string.Empty, null));
 
                 // Then
                 result.IsArgumentOutOfRangeException("sourceBranch");
@@ -41,7 +41,7 @@
             public void Should_Throw_If_SourceBranch_Is_WhiteSpace()
             {
                 // Given / When
-                var result = Record.Exception(() => new TfsPullRequestSettings(new Uri("http://example.com"), " "));
+                var result = Record.Exception(() => new TfsPullRequestSettings(new Uri("http://example.com"), " ", null));
 
                 // Then
                 result.IsArgumentOutOfRangeException("sourceBranch");
@@ -51,7 +51,7 @@
             public void Should_Throw_If_RepositoryUrl_For_PullRequestId_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => new TfsPullRequestSettings((Uri)null, 0));
+                var result = Record.Exception(() => new TfsPullRequestSettings((Uri)null, 0, null));
 
                 // Then
                 result.IsArgumentNullException("repositoryUrl");

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/AuthenticationProvider.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/AuthenticationProvider.cs
@@ -1,0 +1,80 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Authentication
+{
+    /// <summary>
+    /// Class providing credentials for different authentication schemas.
+    /// </summary>
+    internal static class AuthenticationProvider
+    {
+        /// <summary>
+        /// Returns credentials for integrated / NTLM authentication.
+        /// Can only be used for on-premise Team Foundation Server.
+        /// </summary>
+        /// <returns>Credentials for integrated / NTLM authentication.</returns>
+        public static IPrcaCredentials AuthenticationNtlm()
+        {
+            return new PrcaNtlmCredentials();
+        }
+
+        /// <summary>
+        /// Returns credentials for basic authentication.
+        /// Can only be used for on-premise Team Foundation Server configured for basic authentication.
+        /// See https://www.visualstudio.com/en-us/docs/integrate/get-started/auth/tfs-basic-auth.
+        /// </summary>
+        /// <param name="userName">User name.</param>
+        /// <param name="password">Password.</param>
+        /// <returns>Credentials for basic authentication.</returns>
+        public static IPrcaCredentials AuthenticationBasic(
+            string userName,
+            string password)
+        {
+            userName.NotNullOrWhiteSpace(nameof(userName));
+            password.NotNullOrWhiteSpace(nameof(password));
+
+            return new PrcaBasicCredentials(userName, password);
+        }
+
+        /// <summary>
+        /// Returns credentials for authentication with a personal access token.
+        /// Can be used for Team Foundation Server and Visual Studio Team Services.
+        /// </summary>
+        /// <param name="personalAccessToken">Personal access token.</param>
+        /// <returns>Credentials for authentication with a personal access token.</returns>
+        public static IPrcaCredentials AuthenticationPersonalAccessToken(
+            string personalAccessToken)
+        {
+            personalAccessToken.NotNullOrWhiteSpace(nameof(personalAccessToken));
+
+            return new PrcaBasicCredentials(string.Empty, personalAccessToken);
+        }
+
+        /// <summary>
+        /// Returns credentials for OAuth authentication.
+        /// Can only be used with Visual Studio Team Services.
+        /// </summary>
+        /// <param name="accessToken">OAuth access token.</param>
+        /// <returns>Credentials for OAuth authentication.</returns>
+        public static IPrcaCredentials AuthenticationOAuth(
+            string accessToken)
+        {
+            accessToken.NotNullOrWhiteSpace(nameof(accessToken));
+
+            return new PrcaOAuthCredentials(accessToken);
+        }
+
+        /// <summary>
+        /// Returns credentials for authentication with an Azure Active Directory.
+        /// </summary>
+        /// <param name="userName">User name.</param>
+        /// <param name="password">Password.</param>
+        /// <returns>Credentials for authentication with an Azure Active Directory.</returns>
+        public static IPrcaCredentials AuthenticationAzureActiveDirectory(
+            string userName,
+            string password)
+        {
+            userName.NotNullOrWhiteSpace(nameof(userName));
+            password.NotNullOrWhiteSpace(nameof(password));
+
+            return new PrcaAadCredentials(userName, password);
+        }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/PrcaAadCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/PrcaAadCredentials.cs
@@ -1,0 +1,18 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Authentication
+{
+    /// <summary>
+    /// Credentials for authentication with an Azure Active Directory.
+    /// </summary>
+    public class PrcaAadCredentials : PrcaBasicCredentials
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrcaAadCredentials"/> class.
+        /// </summary>
+        /// <param name="userName">User name.</param>
+        /// <param name="password">Password.</param>
+        public PrcaAadCredentials(string userName, string password)
+            : base(userName, password)
+        {
+        }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/PrcaBasicCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/PrcaBasicCredentials.cs
@@ -1,0 +1,29 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Authentication
+{
+    /// <summary>
+    /// Credentials for basic authentication.
+    /// </summary>
+    public class PrcaBasicCredentials : IPrcaCredentials
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrcaBasicCredentials"/> class.
+        /// </summary>
+        /// <param name="userName">User name.</param>
+        /// <param name="password">Password.</param>
+        public PrcaBasicCredentials(string userName, string password)
+        {
+            this.UserName = userName;
+            this.Password = password;
+        }
+
+        /// <summary>
+        /// Gets the user name.
+        /// </summary>
+        public string UserName { get; private set; }
+
+        /// <summary>
+        /// Gets the password.
+        /// </summary>
+        public string Password { get; private set; }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/PrcaNtlmCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/PrcaNtlmCredentials.cs
@@ -1,0 +1,9 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Authentication
+{
+    /// <summary>
+    /// Credentials for integrated / NTLM authentication.
+    /// </summary>
+    public class PrcaNtlmCredentials : IPrcaCredentials
+    {
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/PrcaOAuthCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/PrcaOAuthCredentials.cs
@@ -1,0 +1,24 @@
+﻿namespace Cake.Prca.PullRequests.Tfs.Authentication
+{
+    /// <summary>
+    /// Credentials for OAuth authentication.
+    /// </summary>
+    public class PrcaOAuthCredentials : IPrcaCredentials
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PrcaOAuthCredentials"/> class.
+        /// </summary>
+        /// <param name="accessToken">OAuth access token.</param>
+        public PrcaOAuthCredentials(string accessToken)
+        {
+            accessToken.NotNullOrWhiteSpace(nameof(accessToken));
+
+            this.AccessToken = accessToken;
+        }
+
+        /// <summary>
+        /// Gets the OAuth access token.
+        /// </summary>
+        public string AccessToken { get; private set; }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs/Cake.Prca.PullRequests.Tfs.csproj
+++ b/src/Cake.Prca.PullRequests.Tfs/Cake.Prca.PullRequests.Tfs.csproj
@@ -149,9 +149,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Authentication\AuthenticationProvider.cs" />
+    <Compile Include="Authentication\PrcaAadCredentials.cs" />
+    <Compile Include="Authentication\PrcaOAuthCredentials.cs" />
+    <Compile Include="Authentication\PrcaBasicCredentials.cs" />
     <Compile Include="CommentExtensions.cs" />
     <Compile Include="CommentThreadStatusExtensions.cs" />
     <Compile Include="GitPullRequestCommentThreadExtensions.cs" />
+    <Compile Include="IPrcaCredentials.cs" />
+    <Compile Include="PrcaCredentialsExtensions.cs" />
+    <Compile Include="Authentication\PrcaNtlmCredentials.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepositoryDescription.cs" />
     <Compile Include="TfsPullRequestSettings.cs" />

--- a/src/Cake.Prca.PullRequests.Tfs/IPrcaCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/IPrcaCredentials.cs
@@ -1,0 +1,9 @@
+﻿namespace Cake.Prca.PullRequests.Tfs
+{
+    /// <summary>
+    /// Interface for different credential types.
+    /// </summary>
+    public interface IPrcaCredentials
+    {
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs/PrcaCredentialsExtensions.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/PrcaCredentialsExtensions.cs
@@ -1,0 +1,44 @@
+﻿namespace Cake.Prca.PullRequests.Tfs
+{
+    using Authentication;
+    using Microsoft.VisualStudio.Services.Client;
+    using Microsoft.VisualStudio.Services.Common;
+    using Microsoft.VisualStudio.Services.OAuth;
+
+    /// <summary>
+    /// Extensions for the <see cref="IPrcaCredentials"/> interface.
+    /// </summary>
+    internal static class PrcaCredentialsExtensions
+    {
+        /// <summary>
+        /// Returns the <see cref="VssCredentials"/> corresponding to a <see cref="IPrcaCredentials"/> object.
+        /// </summary>
+        /// <param name="credentials"><see cref="IPrcaCredentials"/> credential instance.</param>
+        /// <returns><see cref="VssCredentials"/> instance.</returns>
+        public static VssCredentials ToVssCredentials(this IPrcaCredentials credentials)
+        {
+            credentials.NotNull(nameof(credentials));
+
+            switch (credentials.GetType().Name)
+            {
+                case nameof(PrcaNtlmCredentials):
+                    return new VssCredentials();
+
+                case nameof(PrcaBasicCredentials):
+                    var basicCredentials = (PrcaBasicCredentials)credentials;
+                    return new VssBasicCredential(basicCredentials.UserName, basicCredentials.Password);
+
+                case nameof(PrcaOAuthCredentials):
+                    var oAuthCredentials = (PrcaOAuthCredentials)credentials;
+                    return new VssOAuthAccessTokenCredential(oAuthCredentials.AccessToken);
+
+                case nameof(PrcaAadCredentials):
+                    var aadCredentials = (PrcaAadCredentials)credentials;
+                    return new VssAadCredential(aadCredentials.UserName, aadCredentials.Password);
+
+                default:
+                    throw new PrcaException("Unknown credential type.");
+            }
+        }
+    }
+}

--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSettings.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSettings.cs
@@ -64,7 +64,7 @@
         public int? PullRequestId { get; private set; }
 
         /// <summary>
-        /// Gets the credetials used to authenticate against Team Foundation Server or
+        /// Gets the credentials used to authenticate against Team Foundation Server or
         /// Visual Studio Team Services.
         /// </summary>
         public IPrcaCredentials Credentials { get; private set; }

--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSettings.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSettings.cs
@@ -15,13 +15,17 @@
         /// Supported URL schemes are HTTP, HTTPS and SSH.
         /// URLs using SSH scheme are converted to HTTPS.</param>
         /// <param name="sourceBranch">Branch for which the pull request is made.</param>
-        public TfsPullRequestSettings(Uri repositoryUrl, string sourceBranch)
+        /// <param name="credentials">Credentials to use to authenticate against Team Foundation Server or
+        /// Visual Studio Team Services.</param>
+        public TfsPullRequestSettings(Uri repositoryUrl, string sourceBranch, IPrcaCredentials credentials)
         {
             repositoryUrl.NotNull(nameof(repositoryUrl));
             sourceBranch.NotNullOrWhiteSpace(nameof(sourceBranch));
+            credentials.NotNull(nameof(credentials));
 
             this.RepositoryUrl = repositoryUrl;
             this.SourceBranch = sourceBranch;
+            this.Credentials = credentials;
         }
 
         /// <summary>
@@ -32,12 +36,16 @@
         /// Supported URL schemes are HTTP, HTTPS and SSH.
         /// URLs using SSH scheme are converted to HTTPS.</param>
         /// <param name="pullRequestId">ID of the pull request.</param>
-        public TfsPullRequestSettings(Uri repositoryUrl, int pullRequestId)
+        /// <param name="credentials">Credentials to use to authenticate against Team Foundation Server or
+        /// Visual Studio Team Services.</param>
+        public TfsPullRequestSettings(Uri repositoryUrl, int pullRequestId, IPrcaCredentials credentials)
         {
             repositoryUrl.NotNull(nameof(repositoryUrl));
+            credentials.NotNull(nameof(credentials));
 
             this.RepositoryUrl = repositoryUrl;
             this.PullRequestId = pullRequestId;
+            this.Credentials = credentials;
         }
 
         /// <summary>
@@ -54,5 +62,11 @@
         /// Gets the ID of the pull request.
         /// </summary>
         public int? PullRequestId { get; private set; }
+
+        /// <summary>
+        /// Gets the credetials used to authenticate against Team Foundation Server or
+        /// Visual Studio Team Services.
+        /// </summary>
+        public IPrcaCredentials Credentials { get; private set; }
     }
 }

--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystem.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystem.cs
@@ -9,7 +9,6 @@
     using Core.IO;
     using Issues;
     using Microsoft.TeamFoundation.SourceControl.WebApi;
-    using Microsoft.VisualStudio.Services.Common;
     using Microsoft.VisualStudio.Services.WebApi;
 
     /// <summary>
@@ -17,6 +16,7 @@
     /// </summary>
     public sealed class TfsPullRequestSystem : PullRequestSystem
     {
+        private readonly TfsPullRequestSettings settings;
         private readonly RepositoryDescription repositoryDescription;
         private readonly GitPullRequest pullRequest;
 
@@ -32,6 +32,8 @@
             : base(log)
         {
             settings.NotNull(nameof(settings));
+
+            this.settings = settings;
 
             this.repositoryDescription = new RepositoryDescription(settings.RepositoryUrl);
 
@@ -269,7 +271,10 @@
 
         private GitHttpClient CreateGitClient()
         {
-            var connection = new VssConnection(this.repositoryDescription.CollectionUrl, new VssCredentials());
+            var connection =
+                new VssConnection(
+                    this.repositoryDescription.CollectionUrl,
+                    this.settings.Credentials.ToVssCredentials());
 
             var gitClient = connection.GetClient<GitHttpClient>();
             if (gitClient == null)

--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystemAliases.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystemAliases.cs
@@ -1,6 +1,7 @@
 ﻿namespace Cake.Prca.PullRequests.Tfs
 {
     using System;
+    using Authentication;
     using Core;
     using Core.Annotations;
 
@@ -13,6 +14,104 @@
     public static class TfsPullRequestSystemAliases
     {
         /// <summary>
+        /// Returns credentials for integrated / NTLM authentication.
+        /// Can only be used for on-premise Team Foundation Server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <returns>Credentials for integrated / NTLM authentication</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
+        public static IPrcaCredentials PrcaAuthenticationNtlm(
+            this ICakeContext context)
+        {
+            context.NotNull(nameof(context));
+
+            return AuthenticationProvider.AuthenticationNtlm();
+        }
+
+        /// <summary>
+        /// Returns credentials for basic authentication.
+        /// Can only be used for on-premise Team Foundation Server configured for basic authentication.
+        /// See https://www.visualstudio.com/en-us/docs/integrate/get-started/auth/tfs-basic-auth.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="userName">User name.</param>
+        /// <param name="password">Password.</param>
+        /// <returns>Credentials for basic authentication.</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
+        public static IPrcaCredentials PrcaAuthenticationBasic(
+            this ICakeContext context,
+            string userName,
+            string password)
+        {
+            context.NotNull(nameof(context));
+            userName.NotNullOrWhiteSpace(nameof(userName));
+            password.NotNullOrWhiteSpace(nameof(password));
+
+            return AuthenticationProvider.AuthenticationBasic(userName, password);
+        }
+
+        /// <summary>
+        /// Returns credentials for authentication with a personal access token.
+        /// Can be used for Team Foundation Server and Visual Studio Team Services.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="personalAccessToken">Personal access token.</param>
+        /// <returns>Credentials for authentication with a personal access token.</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
+        public static IPrcaCredentials PrcaAuthenticationPersonalAccessToken(
+            this ICakeContext context,
+            string personalAccessToken)
+        {
+            context.NotNull(nameof(context));
+            personalAccessToken.NotNullOrWhiteSpace(nameof(personalAccessToken));
+
+            return AuthenticationProvider.AuthenticationPersonalAccessToken(personalAccessToken);
+        }
+
+        /// <summary>
+        /// Returns credentials for OAuth authentication.
+        /// Can only be used with Visual Studio Team Services.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="accessToken">OAuth access token.</param>
+        /// <returns>Credentials for OAuth authentication.</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
+        public static IPrcaCredentials PrcaAuthenticationOAuth(
+            this ICakeContext context,
+            string accessToken)
+        {
+            context.NotNull(nameof(context));
+            accessToken.NotNullOrWhiteSpace(nameof(accessToken));
+
+            return AuthenticationProvider.AuthenticationOAuth(accessToken);
+        }
+
+        /// <summary>
+        /// Returns credentials for authentication with an Azure Active Directory.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="userName">User name.</param>
+        /// <param name="password">Password.</param>
+        /// <returns>Credentials for authentication with an Azure Active Directory.</returns>
+        [CakeMethodAlias]
+        [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
+        public static IPrcaCredentials PrcaAuthenticationAzureActiveDirectory(
+            this ICakeContext context,
+            string userName,
+            string password)
+        {
+            context.NotNull(nameof(context));
+            userName.NotNullOrWhiteSpace(nameof(userName));
+            password.NotNullOrWhiteSpace(nameof(password));
+
+            return AuthenticationProvider.AuthenticationAzureActiveDirectory(userName, password);
+        }
+
+        /// <summary>
         /// Gets an object for writing issues to Team Foundation Server or Visual Studio Team Services pull request
         /// in a specific repository and for a specific source branch.
         /// </summary>
@@ -22,6 +121,8 @@
         /// Supported URL schemes are HTTP, HTTPS and SSH.
         /// URLs using SSH scheme are converted to HTTPS.</param>
         /// <param name="sourceBranch">Branch for which the pull request is made.</param>
+        /// <param name="credentials">Credentials to use to authenticate against Team Foundation Server or
+        /// Visual Studio Team Services.</param>
         /// <returns>Object for writing issues to Team Foundation Server or Visual Studio Team Services pull request.</returns>
         /// <example>
         /// <para>Report code analysis issues reported as MsBuild warnings to a TFS pull request:</para>
@@ -32,7 +133,10 @@
         ///             @"C:\build\msbuild.log",
         ///             MsBuildXmlFileLoggerFormat,
         ///             new DirectoryPath("c:\repo")),
-        ///         TfsPullRequests(new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"), "refs/heads/feature/myfeature"));
+        ///         TfsPullRequests(
+        ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
+        ///             "refs/heads/feature/myfeature",
+        ///             PrcaAuthenticationNtlm()));
         /// ]]>
         /// </code>
         /// </example>
@@ -41,13 +145,15 @@
         public static IPullRequestSystem TfsPullRequests(
             this ICakeContext context,
             Uri repositoryUrl,
-            string sourceBranch)
+            string sourceBranch,
+            IPrcaCredentials credentials)
         {
             context.NotNull(nameof(context));
             repositoryUrl.NotNull(nameof(repositoryUrl));
             sourceBranch.NotNullOrWhiteSpace(nameof(sourceBranch));
+            credentials.NotNull(nameof(credentials));
 
-            return context.TfsPullRequests(new TfsPullRequestSettings(repositoryUrl, sourceBranch));
+            return context.TfsPullRequests(new TfsPullRequestSettings(repositoryUrl, sourceBranch, credentials));
         }
 
         /// <summary>
@@ -60,6 +166,8 @@
         /// Supported URL schemes are HTTP, HTTPS and SSH.
         /// URLs using SSH scheme are converted to HTTPS.</param>
         /// <param name="pullRequestId">ID of the pull request.</param>
+        /// <param name="credentials">Credentials to use to authenticate against Team Foundation Server or
+        /// Visual Studio Team Services.</param>
         /// <returns>Object for writing issues to Team Foundation Server or Visual Studio Team Services pull request.</returns>
         /// <example>
         /// <para>Report code analysis issues reported as MsBuild warnings to a TFS pull request:</para>
@@ -70,7 +178,10 @@
         ///             @"C:\build\msbuild.log",
         ///             MsBuildXmlFileLoggerFormat,
         ///             new DirectoryPath("c:\repo")),
-        ///         TfsPullRequests(new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"), 5));
+        ///         TfsPullRequests(
+        ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
+        ///             5,
+        ///             PrcaAuthenticationNtlm()));
         /// ]]>
         /// </code>
         /// </example>
@@ -79,12 +190,14 @@
         public static IPullRequestSystem TfsPullRequests(
             this ICakeContext context,
             Uri repositoryUrl,
-            int pullRequestId)
+            int pullRequestId,
+            IPrcaCredentials credentials)
         {
             context.NotNull(nameof(context));
             repositoryUrl.NotNull(nameof(repositoryUrl));
+            credentials.NotNull(nameof(credentials));
 
-            return context.TfsPullRequests(new TfsPullRequestSettings(repositoryUrl, pullRequestId));
+            return context.TfsPullRequests(new TfsPullRequestSettings(repositoryUrl, pullRequestId, credentials));
         }
 
         /// <summary>
@@ -101,7 +214,8 @@
         ///     var pullRequestSettings =
         ///         new TfsPullRequestSettings(
         ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
-        ///             "refs/heads/feature/myfeature");
+        ///             "refs/heads/feature/myfeature",
+        ///             PrcaAuthenticationNtlm());
         ///
         ///     ReportCodeAnalysisIssuesToPullRequest(
         ///         MsBuildCodeAnalysis(


### PR DESCRIPTION
Add support for different authentication methods:

- NTLM
- Basic Authentication
- Personal Access Tokens
- OAuth Authentication
- Azure Active Directory Authentication

Fixes #5 