### PR TITLE
(GH-29) Add setting for error handling in case pull request doesn't exist

### DIFF
--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSettings.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSettings.cs
@@ -68,5 +68,11 @@
         /// Visual Studio Team Services.
         /// </summary>
         public IPrcaCredentials Credentials { get; private set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether an exception should be thrown if no
+        /// pull request exists or not.
+        /// </summary>
+        public bool ThrowExceptionIfPulLRequestDoesNotExist { get; set; } = true;
     }
 }


### PR DESCRIPTION
Adds a property to the settings class to define if an exception should be thrown if pull request does not exist or if only a warning should be logged.

Fixes #29 