### PR TITLE
(GH-27) Rename authentication aliases

### DIFF
--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/AuthenticationProviderTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/AuthenticationProviderTests.cs
@@ -15,7 +15,7 @@
                 var credentials = AuthenticationProvider.AuthenticationNtlm();
 
                 // Then
-                credentials.ShouldBeOfType<PrcaNtlmCredentials>();
+                credentials.ShouldBeOfType<TfsNtlmCredentials>();
             }
         }
 
@@ -88,7 +88,7 @@
                 var credentials = AuthenticationProvider.AuthenticationBasic("foo", "bar");
 
                 // Then
-                credentials.ShouldBeOfType<PrcaBasicCredentials>();
+                credentials.ShouldBeOfType<TfsBasicCredentials>();
             }
 
             [Fact]
@@ -101,8 +101,8 @@
                 var credentials = AuthenticationProvider.AuthenticationBasic(userName, "bar");
 
                 // Then
-                credentials.ShouldBeOfType<PrcaBasicCredentials>();
-                ((PrcaBasicCredentials)credentials).UserName.ShouldBe(userName);
+                credentials.ShouldBeOfType<TfsBasicCredentials>();
+                ((TfsBasicCredentials)credentials).UserName.ShouldBe(userName);
             }
 
             [Fact]
@@ -115,8 +115,8 @@
                 var credentials = AuthenticationProvider.AuthenticationBasic("foo", password);
 
                 // Then
-                credentials.ShouldBeOfType<PrcaBasicCredentials>();
-                ((PrcaBasicCredentials)credentials).Password.ShouldBe(password);
+                credentials.ShouldBeOfType<TfsBasicCredentials>();
+                ((TfsBasicCredentials)credentials).Password.ShouldBe(password);
             }
         }
 
@@ -159,7 +159,7 @@
                 var credentials = AuthenticationProvider.AuthenticationPersonalAccessToken("foo");
 
                 // Then
-                credentials.ShouldBeOfType<PrcaBasicCredentials>();
+                credentials.ShouldBeOfType<TfsBasicCredentials>();
             }
 
             [Fact]
@@ -172,9 +172,9 @@
                 var credentials = AuthenticationProvider.AuthenticationPersonalAccessToken(personalAccessToken);
 
                 // Then
-                credentials.ShouldBeOfType<PrcaBasicCredentials>();
-                ((PrcaBasicCredentials)credentials).UserName.ShouldBe(string.Empty);
-                ((PrcaBasicCredentials)credentials).Password.ShouldBe(personalAccessToken);
+                credentials.ShouldBeOfType<TfsBasicCredentials>();
+                ((TfsBasicCredentials)credentials).UserName.ShouldBe(string.Empty);
+                ((TfsBasicCredentials)credentials).Password.ShouldBe(personalAccessToken);
             }
         }
 
@@ -217,7 +217,7 @@
                 var credentials = AuthenticationProvider.AuthenticationOAuth("foo");
 
                 // Then
-                credentials.ShouldBeOfType<PrcaOAuthCredentials>();
+                credentials.ShouldBeOfType<TfsOAuthCredentials>();
             }
 
             [Fact]
@@ -230,8 +230,8 @@
                 var credentials = AuthenticationProvider.AuthenticationOAuth(accessToken);
 
                 // Then
-                credentials.ShouldBeOfType<PrcaOAuthCredentials>();
-                ((PrcaOAuthCredentials)credentials).AccessToken.ShouldBe(accessToken);
+                credentials.ShouldBeOfType<TfsOAuthCredentials>();
+                ((TfsOAuthCredentials)credentials).AccessToken.ShouldBe(accessToken);
             }
         }
 
@@ -304,7 +304,7 @@
                 var credentials = AuthenticationProvider.AuthenticationAzureActiveDirectory("foo", "bar");
 
                 // Then
-                credentials.ShouldBeOfType<PrcaAadCredentials>();
+                credentials.ShouldBeOfType<TfsAadCredentials>();
             }
 
             [Fact]
@@ -317,8 +317,8 @@
                 var credentials = AuthenticationProvider.AuthenticationAzureActiveDirectory(userName, "bar");
 
                 // Then
-                credentials.ShouldBeOfType<PrcaAadCredentials>();
-                ((PrcaAadCredentials)credentials).UserName.ShouldBe(userName);
+                credentials.ShouldBeOfType<TfsAadCredentials>();
+                ((TfsAadCredentials)credentials).UserName.ShouldBe(userName);
             }
 
             [Fact]
@@ -331,8 +331,8 @@
                 var credentials = AuthenticationProvider.AuthenticationAzureActiveDirectory("foo", password);
 
                 // Then
-                credentials.ShouldBeOfType<PrcaAadCredentials>();
-                ((PrcaAadCredentials)credentials).Password.ShouldBe(password);
+                credentials.ShouldBeOfType<TfsAadCredentials>();
+                ((TfsAadCredentials)credentials).Password.ShouldBe(password);
             }
         }
     }

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaAadCredentialsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaAadCredentialsTests.cs
@@ -16,7 +16,7 @@
             public void Should_Set_User_Name(string userName)
             {
                 // When
-                var credentials = new PrcaAadCredentials(userName, "bar");
+                var credentials = new TfsAadCredentials(userName, "bar");
 
                 // Then
                 credentials.UserName.ShouldBe(userName);
@@ -30,7 +30,7 @@
             public void Should_Set_Password_Name(string password)
             {
                 // When
-                var credentials = new PrcaAadCredentials("foo", password);
+                var credentials = new TfsAadCredentials("foo", password);
 
                 // Then
                 credentials.Password.ShouldBe(password);

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaBasicCredentialsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaBasicCredentialsTests.cs
@@ -16,7 +16,7 @@
             public void Should_Set_User_Name(string userName)
             {
                 // When
-                var credentials = new PrcaBasicCredentials(userName, "bar");
+                var credentials = new TfsBasicCredentials(userName, "bar");
 
                 // Then
                 credentials.UserName.ShouldBe(userName);
@@ -30,7 +30,7 @@
             public void Should_Set_Password_Name(string password)
             {
                 // When
-                var credentials = new PrcaBasicCredentials("foo", password);
+                var credentials = new TfsBasicCredentials("foo", password);
 
                 // Then
                 credentials.Password.ShouldBe(password);

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaNtlmCredentialsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaNtlmCredentialsTests.cs
@@ -12,10 +12,10 @@
             public void Should_Not_Throw()
             {
                 // Given / When
-                var credentials = new PrcaNtlmCredentials();
+                var credentials = new TfsNtlmCredentials();
 
                 // Then
-                credentials.ShouldBeOfType<PrcaNtlmCredentials>();
+                credentials.ShouldBeOfType<TfsNtlmCredentials>();
             }
         }
     }

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaOAuthCredentialsTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Authentication/PrcaOAuthCredentialsTests.cs
@@ -12,7 +12,7 @@
             public void Should_Throw_If_Access_Token_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => new PrcaOAuthCredentials(null));
+                var result = Record.Exception(() => new TfsOAuthCredentials(null));
 
                 // Then
                 result.IsArgumentNullException("accessToken");
@@ -22,7 +22,7 @@
             public void Should_Throw_If_Access_Token_Is_Empty()
             {
                 // Given / When
-                var result = Record.Exception(() => new PrcaOAuthCredentials(string.Empty));
+                var result = Record.Exception(() => new TfsOAuthCredentials(string.Empty));
 
                 // Then
                 result.IsArgumentOutOfRangeException("accessToken");
@@ -32,7 +32,7 @@
             public void Should_Throw_If_Access_Token_Is_WhiteSpace()
             {
                 // Given / When
-                var result = Record.Exception(() => new PrcaOAuthCredentials(" "));
+                var result = Record.Exception(() => new TfsOAuthCredentials(" "));
 
                 // Then
                 result.IsArgumentOutOfRangeException("accessToken");
@@ -45,7 +45,7 @@
                 const string accessToken = "foo";
 
                 // When
-                var credentials = new PrcaOAuthCredentials(accessToken);
+                var credentials = new TfsOAuthCredentials(accessToken);
 
                 // Then
                 credentials.AccessToken.ShouldBe(accessToken);

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/AuthenticationProvider.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/AuthenticationProvider.cs
@@ -12,7 +12,7 @@
         /// <returns>Credentials for integrated / NTLM authentication.</returns>
         public static IPrcaCredentials AuthenticationNtlm()
         {
-            return new PrcaNtlmCredentials();
+            return new TfsNtlmCredentials();
         }
 
         /// <summary>
@@ -30,7 +30,7 @@
             userName.NotNullOrWhiteSpace(nameof(userName));
             password.NotNullOrWhiteSpace(nameof(password));
 
-            return new PrcaBasicCredentials(userName, password);
+            return new TfsBasicCredentials(userName, password);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@
         {
             personalAccessToken.NotNullOrWhiteSpace(nameof(personalAccessToken));
 
-            return new PrcaBasicCredentials(string.Empty, personalAccessToken);
+            return new TfsBasicCredentials(string.Empty, personalAccessToken);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@
         {
             accessToken.NotNullOrWhiteSpace(nameof(accessToken));
 
-            return new PrcaOAuthCredentials(accessToken);
+            return new TfsOAuthCredentials(accessToken);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@
             userName.NotNullOrWhiteSpace(nameof(userName));
             password.NotNullOrWhiteSpace(nameof(password));
 
-            return new PrcaAadCredentials(userName, password);
+            return new TfsAadCredentials(userName, password);
         }
     }
 }

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/TfsAadCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/TfsAadCredentials.cs
@@ -3,14 +3,14 @@
     /// <summary>
     /// Credentials for authentication with an Azure Active Directory.
     /// </summary>
-    public class PrcaAadCredentials : PrcaBasicCredentials
+    public class TfsAadCredentials : TfsBasicCredentials
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PrcaAadCredentials"/> class.
+        /// Initializes a new instance of the <see cref="TfsAadCredentials"/> class.
         /// </summary>
         /// <param name="userName">User name.</param>
         /// <param name="password">Password.</param>
-        public PrcaAadCredentials(string userName, string password)
+        public TfsAadCredentials(string userName, string password)
             : base(userName, password)
         {
         }

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/TfsBasicCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/TfsBasicCredentials.cs
@@ -3,14 +3,14 @@
     /// <summary>
     /// Credentials for basic authentication.
     /// </summary>
-    public class PrcaBasicCredentials : IPrcaCredentials
+    public class TfsBasicCredentials : IPrcaCredentials
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PrcaBasicCredentials"/> class.
+        /// Initializes a new instance of the <see cref="TfsBasicCredentials"/> class.
         /// </summary>
         /// <param name="userName">User name.</param>
         /// <param name="password">Password.</param>
-        public PrcaBasicCredentials(string userName, string password)
+        public TfsBasicCredentials(string userName, string password)
         {
             this.UserName = userName;
             this.Password = password;

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/TfsNtlmCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/TfsNtlmCredentials.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Credentials for integrated / NTLM authentication.
     /// </summary>
-    public class PrcaNtlmCredentials : IPrcaCredentials
+    public class TfsNtlmCredentials : IPrcaCredentials
     {
     }
 }

--- a/src/Cake.Prca.PullRequests.Tfs/Authentication/TfsOAuthCredentials.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/Authentication/TfsOAuthCredentials.cs
@@ -3,13 +3,13 @@
     /// <summary>
     /// Credentials for OAuth authentication.
     /// </summary>
-    public class PrcaOAuthCredentials : IPrcaCredentials
+    public class TfsOAuthCredentials : IPrcaCredentials
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PrcaOAuthCredentials"/> class.
+        /// Initializes a new instance of the <see cref="TfsOAuthCredentials"/> class.
         /// </summary>
         /// <param name="accessToken">OAuth access token.</param>
-        public PrcaOAuthCredentials(string accessToken)
+        public TfsOAuthCredentials(string accessToken)
         {
             accessToken.NotNullOrWhiteSpace(nameof(accessToken));
 

--- a/src/Cake.Prca.PullRequests.Tfs/Cake.Prca.PullRequests.Tfs.csproj
+++ b/src/Cake.Prca.PullRequests.Tfs/Cake.Prca.PullRequests.Tfs.csproj
@@ -150,15 +150,15 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Authentication\AuthenticationProvider.cs" />
-    <Compile Include="Authentication\PrcaAadCredentials.cs" />
-    <Compile Include="Authentication\PrcaOAuthCredentials.cs" />
-    <Compile Include="Authentication\PrcaBasicCredentials.cs" />
+    <Compile Include="Authentication\TfsAadCredentials.cs" />
+    <Compile Include="Authentication\TfsOAuthCredentials.cs" />
+    <Compile Include="Authentication\TfsBasicCredentials.cs" />
     <Compile Include="CommentExtensions.cs" />
     <Compile Include="CommentThreadStatusExtensions.cs" />
     <Compile Include="GitPullRequestCommentThreadExtensions.cs" />
     <Compile Include="IPrcaCredentials.cs" />
     <Compile Include="PrcaCredentialsExtensions.cs" />
-    <Compile Include="Authentication\PrcaNtlmCredentials.cs" />
+    <Compile Include="Authentication\TfsNtlmCredentials.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RepositoryDescription.cs" />
     <Compile Include="TfsPullRequestSettings.cs" />

--- a/src/Cake.Prca.PullRequests.Tfs/PrcaCredentialsExtensions.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/PrcaCredentialsExtensions.cs
@@ -21,19 +21,19 @@
 
             switch (credentials.GetType().Name)
             {
-                case nameof(PrcaNtlmCredentials):
+                case nameof(TfsNtlmCredentials):
                     return new VssCredentials();
 
-                case nameof(PrcaBasicCredentials):
-                    var basicCredentials = (PrcaBasicCredentials)credentials;
+                case nameof(TfsBasicCredentials):
+                    var basicCredentials = (TfsBasicCredentials)credentials;
                     return new VssBasicCredential(basicCredentials.UserName, basicCredentials.Password);
 
-                case nameof(PrcaOAuthCredentials):
-                    var oAuthCredentials = (PrcaOAuthCredentials)credentials;
+                case nameof(TfsOAuthCredentials):
+                    var oAuthCredentials = (TfsOAuthCredentials)credentials;
                     return new VssOAuthAccessTokenCredential(oAuthCredentials.AccessToken);
 
-                case nameof(PrcaAadCredentials):
-                    var aadCredentials = (PrcaAadCredentials)credentials;
+                case nameof(TfsAadCredentials):
+                    var aadCredentials = (TfsAadCredentials)credentials;
                     return new VssAadCredential(aadCredentials.UserName, aadCredentials.Password);
 
                 default:

--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystemAliases.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystemAliases.cs
@@ -40,7 +40,7 @@
         /// <returns>Credentials for basic authentication.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
-        public static IPrcaCredentials PrcaAuthenticationBasic(
+        public static IPrcaCredentials TfsAuthenticationBasic(
             this ICakeContext context,
             string userName,
             string password)
@@ -61,7 +61,7 @@
         /// <returns>Credentials for authentication with a personal access token.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
-        public static IPrcaCredentials PrcaAuthenticationPersonalAccessToken(
+        public static IPrcaCredentials TfsAuthenticationPersonalAccessToken(
             this ICakeContext context,
             string personalAccessToken)
         {
@@ -80,7 +80,7 @@
         /// <returns>Credentials for OAuth authentication.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
-        public static IPrcaCredentials PrcaAuthenticationOAuth(
+        public static IPrcaCredentials TfsAuthenticationOAuth(
             this ICakeContext context,
             string accessToken)
         {
@@ -99,7 +99,7 @@
         /// <returns>Credentials for authentication with an Azure Active Directory.</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
-        public static IPrcaCredentials PrcaAuthenticationAzureActiveDirectory(
+        public static IPrcaCredentials TfsAuthenticationAzureActiveDirectory(
             this ICakeContext context,
             string userName,
             string password)
@@ -137,7 +137,7 @@
         ///         TfsPullRequests(
         ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
         ///             "refs/heads/feature/myfeature",
-        ///             PrcaAuthenticationNtlm()),
+        ///             TfsAuthenticationNtlm()),
         ///         repoRoot);
         /// ]]>
         /// </code>
@@ -184,7 +184,7 @@
         ///         TfsPullRequests(
         ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
         ///             5,
-        ///             PrcaAuthenticationNtlm()),
+        ///             TfsAuthenticationNtlm()),
         ///         repoRoot);
         /// ]]>
         /// </code>
@@ -220,7 +220,7 @@
         ///         new TfsPullRequestSettings(
         ///             new Uri("http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository"),
         ///             "refs/heads/feature/myfeature",
-        ///             PrcaAuthenticationNtlm());
+        ///             TfsAuthenticationNtlm());
         ///
         ///     ReportCodeAnalysisIssuesToPullRequest(
         ///         MsBuildCodeAnalysis(


### PR DESCRIPTION
Rename prefix in authentication aliases from `Prca` to `Tfs`.

Fixes #27 