### PR TITLE
(GH-26) Update Cake.Prca to 0.3.0

### DIFF
--- a/nuspec/nuget/Cake.Prca.PullRequests.Tfs.nuspec
+++ b/nuspec/nuget/Cake.Prca.PullRequests.Tfs.nuspec
@@ -16,7 +16,7 @@
     <tags>Cake Script PullRequest CodeAnalysis Cake-Prca-PullRequestSystem TFS VSTS Linting</tags>
     <releaseNotes>https://github.com/cake-contrib/Cake.Prca.PullRequests.Tfs/releases/tag/0.2.2</releaseNotes>
     <dependencies>
-      <dependency id="Cake.Prca" version="[0.2,0.3)" />
+      <dependency id="Cake.Prca" version="[0.3,0.4)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/Cake.Prca.PullRequests.Tfs.Tests.csproj
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/Cake.Prca.PullRequests.Tfs.Tests.csproj
@@ -40,7 +40,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Prca, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Prca.0.2.1\lib\net45\Cake.Prca.dll</HintPath>
+      <HintPath>..\packages\Cake.Prca.0.3.0-beta0002\lib\net45\Cake.Prca.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Testing, Version=0.16.2.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/ContentProviderTests.cs
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/ContentProviderTests.cs
@@ -39,7 +39,7 @@
                 string expectedResult)
             {
                 // Given
-                var issue = new CodeAnalysisIssue(filePath, line, message, priority, rule);
+                var issue = new CodeAnalysisIssue(filePath, line, message, priority, rule, null, "Foo");
 
                 // When
                 var result = ContentProvider.GetContent(issue);

--- a/src/Cake.Prca.PullRequests.Tfs.Tests/packages.config
+++ b/src/Cake.Prca.PullRequests.Tfs.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
-  <package id="Cake.Prca" version="0.2.1" targetFramework="net452" />
+  <package id="Cake.Prca" version="0.3.0-beta0002" targetFramework="net452" />
   <package id="Cake.Testing" version="0.16.2" targetFramework="net452" />
   <package id="Shouldly" version="2.8.2" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />

--- a/src/Cake.Prca.PullRequests.Tfs/Cake.Prca.PullRequests.Tfs.csproj
+++ b/src/Cake.Prca.PullRequests.Tfs/Cake.Prca.PullRequests.Tfs.csproj
@@ -42,7 +42,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Prca, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Prca.0.2.1\lib\net45\Cake.Prca.dll</HintPath>
+      <HintPath>..\packages\Cake.Prca.0.3.0-beta0001\lib\net45\Cake.Prca.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.13.5.907, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Cake.Prca.PullRequests.Tfs/Cake.Prca.PullRequests.Tfs.csproj
+++ b/src/Cake.Prca.PullRequests.Tfs/Cake.Prca.PullRequests.Tfs.csproj
@@ -42,7 +42,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Cake.Prca, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Prca.0.3.0-beta0001\lib\net45\Cake.Prca.dll</HintPath>
+      <HintPath>..\packages\Cake.Prca.0.3.0-beta0002\lib\net45\Cake.Prca.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.13.5.907, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystem.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystem.cs
@@ -99,7 +99,7 @@
         }
 
         /// <inheritdoc/>
-        public override IEnumerable<IPrcaDiscussionThread> FetchActiveDiscussionThreads(string commentSource)
+        protected override IEnumerable<IPrcaDiscussionThread> InternalFetchActiveDiscussionThreads(string commentSource)
         {
             if (!this.ValidatePullRequest())
             {
@@ -143,7 +143,7 @@
         }
 
         /// <inheritdoc/>
-        public override IEnumerable<FilePath> GetModifiedFilesInPullRequest()
+        protected override IEnumerable<FilePath> InternalGetModifiedFilesInPullRequest()
         {
             if (!this.ValidatePullRequest())
             {
@@ -197,7 +197,7 @@
         }
 
         /// <inheritdoc/>
-        public override void MarkThreadsAsFixed(IEnumerable<IPrcaDiscussionThread> threads)
+        protected override void InternalMarkThreadsAsFixed(IEnumerable<IPrcaDiscussionThread> threads)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             threads.NotNull(nameof(threads));
@@ -229,7 +229,7 @@
         }
 
         /// <inheritdoc/>
-        public override void PostDiscussionThreads(IEnumerable<ICodeAnalysisIssue> issues, string commentSource)
+        protected override void InternalPostDiscussionThreads(IEnumerable<ICodeAnalysisIssue> issues, string commentSource)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             issues.NotNull(nameof(issues));

--- a/src/Cake.Prca.PullRequests.Tfs/packages.config
+++ b/src/Cake.Prca.PullRequests.Tfs/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
-  <package id="Cake.Prca" version="0.2.1" targetFramework="net452" />
+  <package id="Cake.Prca" version="0.3.0-beta0001" targetFramework="net452" />
   <package id="Costura.Fody" version="1.3.3.0" targetFramework="net452" developmentDependency="true" />
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net452" />
   <package id="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />

--- a/src/Cake.Prca.PullRequests.Tfs/packages.config
+++ b/src/Cake.Prca.PullRequests.Tfs/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Cake.Core" version="0.16.2" targetFramework="net452" />
-  <package id="Cake.Prca" version="0.3.0-beta0001" targetFramework="net452" />
+  <package id="Cake.Prca" version="0.3.0-beta0002" targetFramework="net452" />
   <package id="Costura.Fody" version="1.3.3.0" targetFramework="net452" developmentDependency="true" />
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net452" />
   <package id="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />


### PR DESCRIPTION
Updates Cake.Prca to 0.3.0.

Fixes #26 