### PR TITLE
(GH-27) Rename authentication alias for Ntlm

### DIFF
--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystemAliases.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystemAliases.cs
@@ -21,7 +21,7 @@
         /// <returns>Credentials for integrated / NTLM authentication</returns>
         [CakeMethodAlias]
         [CakeAliasCategory(CakeAliasConstants.PullRequestSystemCakeAliasCategory)]
-        public static IPrcaCredentials PrcaAuthenticationNtlm(
+        public static IPrcaCredentials TfsAuthenticationNtlm(
             this ICakeContext context)
         {
             context.NotNull(nameof(context));


### PR DESCRIPTION
The alias for NTLM authentication was not renamed as part of #35