### PR TITLE
(GH-60) Fail initialization if no pull request could be found

### DIFF
--- a/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystem.cs
+++ b/src/Cake.Prca.PullRequests.Tfs/TfsPullRequestSystem.cs
@@ -135,6 +135,13 @@
         }
 
         /// <inheritdoc/>
+        public override bool Initialize(ReportIssuesToPullRequestSettings settings)
+        {
+            // Fail initialization if no pull request could be found.
+            return base.Initialize(settings) && this.pullRequest != null;
+        }
+
+        /// <inheritdoc/>
         public override PrcaCommentFormat GetPreferredCommentFormat()
         {
             return PrcaCommentFormat.Markdown;


### PR DESCRIPTION
Fail initialization if no pull request could be found.

Based on #64 and requires rebasing after #64 is merged.

Fixes #60 